### PR TITLE
New note context menu

### DIFF
--- a/src/map-view.ts
+++ b/src/map-view.ts
@@ -232,7 +232,7 @@ export class MapView extends BasesView {
 				this.updateMarkers();
 			}
 			// Apply config to map on first load or when config changes
-			if (this.isFirstLoad || configChanged) {
+			if (configChanged) {
 				void this.applyConfigToMap();
 				this.lastConfigSnapshot = configSnapshot;
 				this.isFirstLoad = false;
@@ -464,7 +464,7 @@ export class MapView extends BasesView {
 			.setSection('action')
 			.setIcon('square-pen')
 			.onClick(() => {
-				void this.createFileForView('Untitled', (frontmatter) => {
+				void this.createFileForView('', (frontmatter) => {
 					// Pre-fill coordinates if a coordinates property is configured
 					if (this.coordinatesProp) {
 						// Remove 'note.' prefix if present


### PR DESCRIPTION
- Context menu for new note
- Avoid reloading the whole map when a pin is added
- Remove unnecessary lucide icon prefixes
- Don't push the context menu options to existing pins