### PR TITLE
Draw lines for linked markers

### DIFF
--- a/src/map-view.ts
+++ b/src/map-view.ts
@@ -24,6 +24,7 @@ interface MapConfig {
 	coordinatesProp: BasesPropertyId | null;
 	markerIconProp: BasesPropertyId | null;
 	markerColorProp: BasesPropertyId | null;
+	markerNeighboursProp: BasesPropertyId | null;
 	mapHeight: number;
 	defaultZoom: number;
 	center: [number, number];
@@ -442,6 +443,7 @@ export class MapView extends BasesView {
 		const coordinatesProp = this.config.getAsPropertyId('coordinates');
 		const markerIconProp = this.config.getAsPropertyId('markerIcon');
 		const markerColorProp = this.config.getAsPropertyId('markerColor');
+		const markerNeighboursProp = this.config.getAsPropertyId('markerNeighbours');
 
 		// Load numeric configurations with validation
 		const minZoom = this.getNumericConfig('minZoom', 0, 0, 24);
@@ -493,6 +495,7 @@ export class MapView extends BasesView {
 			coordinatesProp,
 			markerIconProp,
 			markerColorProp,
+			markerNeighboursProp,
 			mapHeight,
 			defaultZoom,
 			center,
@@ -750,6 +753,13 @@ export class MapView extends BasesView {
 						displayName: 'Marker color',
 						type: 'property',
 						key: 'markerColor',
+						filter: prop => !prop.startsWith('file.'),
+						placeholder: 'Property',
+					},
+					{
+						displayName: 'Linked markers',
+						type: 'property',
+						key: 'markerNeighbours',
 						filter: prop => !prop.startsWith('file.'),
 						placeholder: 'Property',
 					},

--- a/src/map/markers.ts
+++ b/src/map/markers.ts
@@ -544,9 +544,13 @@ export class MarkerManager {
 			const fromCoord = marker.coordinates; // [lat, lng]
 
 			for (const linkPath of neighbours) {
+				// Avoid self-links
+				if (linkPath === fromPath) continue;
+
 				// Only if neighbour is displayed as a marker
 				const targetIndex = pathToIndex.get(linkPath);
 				if (targetIndex === undefined) continue;
+
 				const toCoord = validMarkers[targetIndex].coordinates;
 
 				// Deduplicate undirected edges by keying on sorted path pair

--- a/src/map/markers.ts
+++ b/src/map/markers.ts
@@ -511,71 +511,60 @@ export class MarkerManager {
 		});
 	}
 
-	private updateNeighbourConnections(validMarkers: MapMarker[]): void {
+	private updateNeighbourConnections(markers: MapMarker[]): void {
 		if (!this.map) return;
-
 		const mapConfig = this.getMapConfig();
+		const prop = mapConfig?.markerNeighboursProp;
+		
 		this.ensureNeighbourLayer();
-
-		const neighbourSource = this.map.getSource('marker-neighbours') as GeoJSONSource | undefined;
-		if (!neighbourSource) return;
-
-		// If no neighbours property is configured, clear the lines
-		if (!mapConfig || !mapConfig.markerNeighboursProp) {
-			neighbourSource.setData({ type: 'FeatureCollection', features: [] });
+		
+		const source = this.map.getSource("marker-neighbours") as GeoJSONSource | undefined;
+		if (!source) return;
+		
+		if (!prop || markers.length === 0) {
+			source.setData({ type: "FeatureCollection", features: [] });
 			return;
 		}
-
-		// Build path -> marker index map for fast lookup
-		const pathToIndex = new Map<string, number>();
-		for (let i = 0; i < validMarkers.length; i++) {
-			pathToIndex.set(validMarkers[i].entry.file.path, i);
-		}
-
-		// Build unique edges
+		
+		const byPath = new Map(markers.map((m, i) => [m.entry.file.path, i] as const));
+		
 		const edgeKeys = new Set<string>();
-		const features: GeoJSON.Feature[] = [];
-
-		for (const marker of validMarkers) {
-			const neighbours = this.extractNeighbourPaths(marker.entry, mapConfig.markerNeighboursProp);
-			if (neighbours.length === 0) continue;
-
-			const fromPath = marker.entry.file.path;
-			const fromCoord = marker.coordinates; // [lat, lng]
-
-			for (const linkPath of neighbours) {
+		const features: GeoJSON.Feature<GeoJSON.LineString>[] = [];
+		
+		for (const from of markers) {
+			const fromPath = from.entry.file.path;
+		    const toPaths = this.extractNeighbourPaths(from.entry, prop);
+			
+			for (const toPath of toPaths) {
 				// Avoid self-links
-				if (linkPath === fromPath) continue;
-
-				// Only if neighbour is displayed as a marker
-				const targetIndex = pathToIndex.get(linkPath);
-				if (targetIndex === undefined) continue;
-
-				const toCoord = validMarkers[targetIndex].coordinates;
-
-				// Deduplicate undirected edges by keying on sorted path pair
-				const key = fromPath < linkPath ? `${fromPath}||${linkPath}` : `${linkPath}||${fromPath}`;
+				if (toPath === fromPath) continue;
+				
+				// Avoid links to non-existing markers
+				const toIndex = byPath.get(toPath);
+				if (toIndex === undefined) continue;
+				
+				// Deduplicate edges
+				const key = fromPath < toPath ? `${fromPath}||${toPath}` : `${toPath}||${fromPath}`;
 				if (edgeKeys.has(key)) continue;
 				edgeKeys.add(key);
-
+				
+				const to = markers[toIndex];
+				
 				features.push({
-					type: 'Feature',
+					type: "Feature",
 					geometry: {
-						type: 'LineString',
+						type: "LineString",
 						coordinates: [
-							[fromCoord[1], fromCoord[0]],
-							[toCoord[1], toCoord[0]],
+							[from.coordinates[1], from.coordinates[0]],
+							[to.coordinates[1], to.coordinates[0]],
 						],
 					},
 					properties: {}
 				});
 			}
 		}
-
-		neighbourSource.setData({
-			type: 'FeatureCollection',
-			features,
-		});
+		
+		source.setData({ type: "FeatureCollection", features });
 	}
 
 	private extractNeighbourPaths(entry: BasesEntry, neighboursProp: BasesPropertyId): string[] {

--- a/src/map/popup.ts
+++ b/src/map/popup.ts
@@ -25,12 +25,13 @@ export class PopupManager {
 		coordinatesProp: BasesPropertyId | null,
 		markerIconProp: BasesPropertyId | null,
 		markerColorProp: BasesPropertyId | null,
+		markerNeighboursProp: BasesPropertyId | null,
 		getDisplayName: (prop: BasesPropertyId) => string
 	): void {
 		if (!this.map) return;
 
 		// Only show popup if there are properties to display
-		if (!properties || properties.length === 0 || !this.hasAnyPropertyValues(entry, properties, coordinatesProp, markerIconProp, markerColorProp)) {
+		if (!properties || properties.length === 0 || !this.hasAnyPropertyValues(entry, properties, coordinatesProp, markerIconProp, markerColorProp, markerNeighboursProp)) {
 			return;
 		}
 
@@ -60,7 +61,7 @@ export class PopupManager {
 
 		// Update popup content and position
 		const [lat, lng] = coordinates;
-		const popupContent = this.createPopupContent(entry, properties, coordinatesProp, markerIconProp, markerColorProp, getDisplayName);
+		const popupContent = this.createPopupContent(entry, properties, coordinatesProp, markerIconProp, markerColorProp, markerNeighboursProp, getDisplayName);
 		this.sharedPopup
 			.setDOMContent(popupContent)
 			.setLngLat([lng, lat])
@@ -104,6 +105,7 @@ export class PopupManager {
 		coordinatesProp: BasesPropertyId | null,
 		markerIconProp: BasesPropertyId | null,
 		markerColorProp: BasesPropertyId | null,
+		markerNeighboursProp: BasesPropertyId | null,
 		getDisplayName: (prop: BasesPropertyId) => string
 	): HTMLElement {
 		const containerEl = createDiv('bases-map-popup');
@@ -113,7 +115,8 @@ export class PopupManager {
 		const propertiesWithValues = [];
 
 		for (const prop of propertiesSlice) {
-			if (prop === coordinatesProp || prop === markerIconProp || prop === markerColorProp) continue; // Skip coordinates, marker icon, and marker color properties
+			// Skip coordinates, marker icon, marker color and marker neighbours properties
+			if (prop === coordinatesProp || prop === markerIconProp || prop === markerColorProp || prop === markerNeighboursProp) continue;
 
 			try {
 				const value = entry.getValue(prop);
@@ -179,12 +182,14 @@ export class PopupManager {
 		properties: BasesPropertyId[],
 		coordinatesProp: BasesPropertyId | null,
 		markerIconProp: BasesPropertyId | null,
-		markerColorProp: BasesPropertyId | null
+		markerColorProp: BasesPropertyId | null,
+		markerNeighboursProp: BasesPropertyId | null
 	): boolean {
 		const propertiesSlice = properties.slice(0, 20); // Max 20 properties
 
 		for (const prop of propertiesSlice) {
-			if (prop === coordinatesProp || prop === markerIconProp || prop === markerColorProp) continue; // Skip coordinates, marker icon, and marker color properties
+			// Skip coordinates, marker icon, marker color and marker neighbours properties
+			if (prop === coordinatesProp || prop === markerIconProp || prop === markerColorProp || prop === markerNeighboursProp) continue;
 
 			try {
 				const value = entry.getValue(prop);
@@ -200,4 +205,3 @@ export class PopupManager {
 		return false;
 	}
 }
-


### PR DESCRIPTION
This PR adds the ability to draw lines between any two markers by supplying a "Linked markers" property.

I understand you may already be planning to go in a different direction for lines - I just wanted to share my quick solution that works for my purposes.

<img width="1165" height="1032" alt="image" src="https://github.com/user-attachments/assets/f1308e70-4d9c-47dd-81b1-1fbaec57aca1" />
