### PR TITLE
Allow zoom to be set by markers

### DIFF
--- a/src/map/markers.ts
+++ b/src/map/markers.ts
@@ -47,6 +47,16 @@ export class MarkerManager {
 		return this.bounds;
 	}
 
+	getWidestMarkerZoom(): number | undefined {
+		const validZoomLevels = this.markers
+			.map(marker => marker.zoom)
+			.filter((z): z is number => z !== undefined);
+
+		if (validZoomLevels.length === 0) return undefined;
+
+		return Math.min(...validZoomLevels);
+	}
+
 	clearLoadedIcons(): void {
 		this.loadedIcons.clear();
 	}
@@ -63,6 +73,7 @@ export class MarkerManager {
 			if (!entry) continue;
 
 			let coordinates: [number, number] | null = null;
+			let zoom: number | undefined = undefined;
 			try {
 				const value = entry.getValue(mapConfig.coordinatesProp);
 				coordinates = coordinateFromValue(value);
@@ -71,10 +82,19 @@ export class MarkerManager {
 				console.error(`Error extracting coordinates for ${entry.file.name}:`, error);
 			}
 
+			try {
+				const value = entry.getValue(mapConfig.zoomProp);
+				zoom = value !== undefined ? Number(value) : undefined;
+			}
+			catch (error) {
+				console.error(`Error extracting zoom for ${entry.file.name}:`, error);
+			}
+
 			if (coordinates) {
 				validMarkers.push({
 					entry,
 					coordinates,
+					zoom,
 				});
 			}
 		}

--- a/src/map/types.ts
+++ b/src/map/types.ts
@@ -3,6 +3,7 @@ import { BasesEntry } from 'obsidian';
 export interface MapMarker {
 	entry: BasesEntry;
 	coordinates: [number, number];
+	zoom?: number;
 }
 
 export interface MapMarkerProperties {


### PR DESCRIPTION
## Overview

Adds a new configuration option to the plugin which allows a user to select the zoom "strategy". This change supports three strategies:

- Default: Zoom is set by the "Default zoom" configuration
- Bounds: Zoom is determined by the bounds of all markers
- Properties: Zoom is set to the widest (lowest number) zoom defined in the markers/notes, according to the property selected in the "Zoom property" configuration

Partially addresses: https://github.com/obsidianmd/obsidian-maps/issues/12

@kepano or others, let me know what you think. Happy to iterate on this. At the moment I don't think the functionality is fully backwards-compatible, compared with the current behavior, but ideally it would be so.

## Use-case

Primarily, embedding a Base inside a note that will display the coordinates and zoom level defined _by that note._

For example, the following note uses an inline Base to render a map of San Francisco, with the zoom level set to 14.

~~~md
---
title: San Francisco
categories:
  - "[[Places]]"
created: 2026-01-06
updated: 2026-01-06
coordinates:
  - "37.779379"
  - "-122.418433"
zoom: 14
---

```base
filters:
  and:
    - categories.containsAny(link("Places"))
    - file == this.file
views:
  - type: map
    name: Single Place
    coordinates: note.coordinates
    zoom: note.zoom
    zoomStrategy: properties
```

~~~

## Screenshots

<img width="329" height="588" alt="Screenshot 2026-01-06 at 2 55 52 PM" src="https://github.com/user-attachments/assets/64a5d901-e4b1-4c0f-ad5d-ec222c35383f" />