### PR TITLE
Fix missing markers on the equator or prime meridian

### DIFF
--- a/src/map/utils.ts
+++ b/src/map/utils.ts
@@ -24,7 +24,7 @@ export function coordinateFromValue(value: Value | null): [number, number] | nul
 		}
 	}
 
-	if (lat && lng && verifyLatLng(lat, lng)) {
+	if (lat != null && lng != null && verifyLatLng(lat, lng)) {
 		return [lat, lng];
 	}
 


### PR DESCRIPTION
A small fix for `coordinateFromValue` to prevent it from returning null when latitude or longitude are 0, allowing markers along the equator or prime meridian to be displayed.