### PR TITLE
Migrate settings to Obsidian 1.13 API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@typescript-eslint/parser": "5.29.0",
 				"builtin-modules": "3.3.0",
 				"esbuild": "^0.25.10",
-				"obsidian": "latest",
+				"obsidian": "^1.13.1",
 				"tslib": "2.8.1",
 				"typescript": "5.9.3"
 			}
@@ -35,9 +35,9 @@
 			}
 		},
 		"node_modules/@codemirror/view": {
-			"version": "6.38.1",
-			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.1.tgz",
-			"integrity": "sha512-RmTOkE7hRU3OVREqFVITWHz6ocgBjv08GoePscAakgVQfciA3SGCEk7mb9IzwW61cKKmlTpHXG6DUE5Ubx+MGQ==",
+			"version": "6.38.6",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
+			"integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -699,9 +699,9 @@
 			}
 		},
 		"node_modules/@marijn/find-cluster-break": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
-			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+			"integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -1207,9 +1207,9 @@
 			"peer": true
 		},
 		"node_modules/crelt": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+			"integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true
@@ -2171,9 +2171,9 @@
 			"peer": true
 		},
 		"node_modules/obsidian": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.10.2.tgz",
-			"integrity": "sha512-bX03YCHf06OTzI/D+QK71ajCPCmwr/cjxzlVXjQa10DjK5iHRWhtJJpp83arSCyayFMp23u+UHcY7hxcEx2Mvg==",
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.13.1.tgz",
+			"integrity": "sha512-qtTEA2pmhJzhuhJqzbBFRYhpIOqvW+krDYjtFynv66KbxBbumHBlsJfWw3I4jtnK/6fZwbQhCrmmDdRwXmX56w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2182,7 +2182,7 @@
 			},
 			"peerDependencies": {
 				"@codemirror/state": "6.5.0",
-				"@codemirror/view": "6.38.1"
+				"@codemirror/view": "6.38.6"
 			}
 		},
 		"node_modules/once": {
@@ -2561,9 +2561,9 @@
 			}
 		},
 		"node_modules/style-mod": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
-			"integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+			"integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"@typescript-eslint/parser": "5.29.0",
 		"builtin-modules": "3.3.0",
 		"esbuild": "^0.25.10",
-		"obsidian": "latest",
+		"obsidian": "^1.13.1",
 		"tslib": "2.8.1",
 		"typescript": "5.9.3"
 	},

--- a/src/map-view.ts
+++ b/src/map-view.ts
@@ -7,7 +7,7 @@ import {
 	Value,
 	StringValue,
 	NullValue,
-	ViewOption,
+	BasesAllOptions,
 } from 'obsidian';
 import { LngLatLike, Map, setRTLTextPlugin } from 'maplibre-gl';
 import type ObsidianMapsPlugin from './main';
@@ -677,7 +677,7 @@ export class MapView extends BasesView {
 		};
 	}
 
-	static getViewOptions(): ViewOption[] {
+	static getViewOptions(): BasesAllOptions[] {
 		return [
 			{
 				displayName: 'Embedded height',

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,4 @@
-import { App, Modal, PluginSettingTab, Setting, setIcon, setTooltip } from 'obsidian';
+import { App, Modal, PluginSettingTab, Setting, type SettingDefinitionItem, requireApiVersion, setIcon, setTooltip } from 'obsidian';
 import ObsidianMapsPlugin from './main';
 
 export interface TileSet {
@@ -100,6 +100,58 @@ export class MapSettingTab extends PluginSettingTab {
 		this.plugin = plugin;
 	}
 
+	private refresh(): void {
+		if (requireApiVersion('1.13.0')) {
+			this.update();
+		} else {
+			this.display();
+		}
+	}
+
+	getSettingDefinitions(): SettingDefinitionItem[] {
+		if (!requireApiVersion('1.13.0')) return [];
+
+		return [
+			{
+				name: 'Backgrounds',
+				render: (setting) => {
+					setting
+						.setHeading()
+						.addButton(button => button
+							.setButtonText('Add background')
+							.setCta()
+							.onClick(() => {
+								new TileSetModal(this.app, null, async (tileSet) => {
+									this.plugin.settings.tileSets.push(tileSet);
+									await this.plugin.saveSettings();
+									this.refresh();
+								}).open();
+							})
+						);
+				}
+			},
+			{
+				name: 'Configured backgrounds',
+				searchable: false,
+				render: (setting) => {
+					setting.settingEl.empty();
+					const listContainer = setting.settingEl.createDiv('map-tileset-list');
+
+					this.plugin.settings.tileSets.forEach((tileSet, index) => {
+						this.displayTileSetItem(listContainer, tileSet, index);
+					});
+
+					if (this.plugin.settings.tileSets.length === 0) {
+						listContainer.createDiv({
+							cls: 'mobile-option-setting-item',
+							text: 'Add background sets available to all maps.'
+						});
+					}
+				}
+			}
+		];
+	}
+
 	display(): void {
 		const { containerEl } = this;
 		containerEl.empty();
@@ -114,7 +166,7 @@ export class MapSettingTab extends PluginSettingTab {
 					new TileSetModal(this.app, null, async (tileSet) => {
 						this.plugin.settings.tileSets.push(tileSet);
 						await this.plugin.saveSettings();
-						this.display();
+						this.refresh();
 					}).open();
 				})
 			);
@@ -146,7 +198,7 @@ export class MapSettingTab extends PluginSettingTab {
 				new TileSetModal(this.app, { ...tileSet }, async (updatedTileSet) => {
 					this.plugin.settings.tileSets[index] = updatedTileSet;
 					await this.plugin.saveSettings();
-					this.display();
+					this.refresh();
 				}).open();
 			});
 		});
@@ -157,9 +209,8 @@ export class MapSettingTab extends PluginSettingTab {
 			el.addEventListener('click', async () => {
 				this.plugin.settings.tileSets.splice(index, 1);
 				await this.plugin.saveSettings();
-				this.display();
+				this.refresh();
 			});
 		});
 	}
 }
-


### PR DESCRIPTION
Adds `getSettingDefinitions()` for Obsidian 1.13 while retaining the legacy `display()` fallback and the custom-rendered controls. Existing map-view update side effects remain unchanged, and the Obsidian API dependency is updated for the new interface.

Source checks and production build pass. A real-app visual smoke test remains recommended for the custom settings controls.